### PR TITLE
Fix build on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ libleveldb.so
 libleveldb.a
 leakydb
 bench/
+deps/*/Release
 *.sln
 *.vcxproj
 *.vcxproj.filters

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "du": "~0.1.0",
     "mkfiletree": "~0.0.1",
     "monotonic-timestamp": "~0.0.8",
-    "node-gyp": "~1.0.1",
     "readfiletree": "~0.0.1",
     "rimraf": "~2.2.8",
     "tap": "~0.4.12"


### PR DESCRIPTION
It appears that having a local `node-gyp` install is causing some problems on Windows, such as that the `node.lib` can't be found (not sure if that's an iojs thing though):
```
gyp ERR! build error
gyp ERR! stack Error: ENOENT: no such file or directory, open 'C:\Users\Jonas\.node-gyp\1.3.0\x64\node.lib'
gyp ERR! stack     at Error (native)
gyp ERR! System Windows_NT 6.3.9600
gyp ERR! command "C:\\Program Files\\iojs\\node.exe" "C:\\Users\\Jonas\\Code\\leveldown-prebuilt\\node_modules\\node-gyp\\bin\\node-gyp.js" "build" "--module=C:\\Users\\Jonas\\Code\\leveldown-prebuilt\\build-pre-gyp\\leveldown.node" "--module_name=leveldown" "--module_path=C:\\Users\\Jonas\\Code\\leveldown-prebuilt\\build-pre-gyp"
gyp ERR! cwd C:\Users\Jonas\Code\leveldown-prebuilt
gyp ERR! node -v v1.3.0
gyp ERR! node-gyp -v v1.0.2
gyp ERR! not ok
```

I couldn't reproduce the `MSB4019` error you mentioned on twitter. After removing the local `node-gyp` the build just went through (on Win 10).
Zip of the build: [leveldown-prebuilt.zip](https://github.com/jhermsmeier/leveldown-prebuilt/releases/download/untagged-7d720b8363e99fc665b9/leveldown-prebuilt.zip)